### PR TITLE
fix: got CS0121 ambiguous call when compiling tests on CI server that…

### DIFF
--- a/Source/Unit Tests/Tests/AsyncProducerConsumerQueueUnitTests.cs
+++ b/Source/Unit Tests/Tests/AsyncProducerConsumerQueueUnitTests.cs
@@ -674,7 +674,7 @@ namespace Tests
         {
             var queue = new AsyncProducerConsumerQueue<int>();
             var seq = queue as IEnumerable<int>;
-            Assert.That(seq.Count, Is.EqualTo(0));
+            Assert.That(seq.Count(), Is.EqualTo(0));
         }
 
         [Test]


### PR DESCRIPTION
… does not occur in local compilation

Fixed by calling the Count extension method instead of passing it as a delegate (was unintentional anyway).
