### PR TITLE
Fixed hang in async queue IsCompleted

### DIFF
--- a/Source/Nito.AsyncEx (NET4, Win8, SL5, WP8, WPA81)/Nito.AsyncEx (NET4, Win8, SL5, WP8, WPA81).csproj
+++ b/Source/Nito.AsyncEx (NET4, Win8, SL5, WP8, WPA81)/Nito.AsyncEx (NET4, Win8, SL5, WP8, WPA81).csproj
@@ -209,6 +209,9 @@
     <Compile Include="..\Nito.AsyncEx %28NET45, Win8, WP8, WPA81%29\ExceptionHelpers.cs">
       <Link>ExceptionHelpers.cs</Link>
     </Compile>
+    <Compile Include="..\Nito.AsyncEx %28NET45, Win8, WP8, WPA81%29\IAsyncProducerConsumerQueue.cs">
+      <Link>IAsyncProducerConsumerQueue.cs</Link>
+    </Compile>
     <Compile Include="..\Nito.AsyncEx %28NET45, Win8, WP8, WPA81%29\Internal\IdManager.cs">
       <Link>Internal\IdManager.cs</Link>
     </Compile>

--- a/Source/Nito.AsyncEx (NET45, Win8, WP8, WPA81)/AsyncProducerConsumerQueue.cs
+++ b/Source/Nito.AsyncEx (NET45, Win8, WP8, WPA81)/AsyncProducerConsumerQueue.cs
@@ -16,7 +16,7 @@ namespace Nito.AsyncEx
     /// <typeparam name="T">The type of elements contained in the queue.</typeparam>
     [DebuggerDisplay("Count = {_queue.Count}, MaxCount = {_maxCount}")]
     [DebuggerTypeProxy(typeof(AsyncProducerConsumerQueue<>.DebugView))]
-    public sealed class AsyncProducerConsumerQueue<T> : IEnumerable<T>, IDisposable
+    public sealed class AsyncProducerConsumerQueue<T> : IEnumerable<T>, IDisposable, IAsyncProducerConsumerQueue<T>
     {
         /// <summary>
         /// The underlying queue.
@@ -63,7 +63,6 @@ namespace Nito.AsyncEx
         /// Gets whether this <see cref="AsyncProducerConsumerQueue{T}"/> has been marked as
         /// complete for adding and is empty.
         /// </summary>
-        /// <remarks>This method executes in time linear in the number of items in the queue.</remarks>
         public bool IsCompleted
         {
             get
@@ -73,7 +72,7 @@ namespace Nito.AsyncEx
                     if (!_completed.IsCancellationRequested)
                         return false;
 
-                    return this.AsEnumerable().Count() == 0;
+                    return _queue.Count == 0;
                 }
             }
         }

--- a/Source/Nito.AsyncEx (NET45, Win8, WP8, WPA81)/IAsyncProducerConsumerQueue.cs
+++ b/Source/Nito.AsyncEx (NET45, Win8, WP8, WPA81)/IAsyncProducerConsumerQueue.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -11,47 +12,156 @@ namespace Nito.AsyncEx
     public interface IAsyncProducerConsumerQueue<T>
     {
         #region Enqueue
+        /// <summary>
+        /// Enqueues an item to the producer/consumer queue. This method may block the calling thread. Throws <see cref="InvalidOperationException"/> if the producer/consumer queue has completed adding.
+        /// </summary>
+        /// <param name="item">The item to enqueue.</param>
         void Enqueue(T item);
+
+        /// <summary>
+        /// Enqueues an item to the producer/consumer queue. Throws <see cref="InvalidOperationException"/> if the producer/consumer queue has completed adding. This method may block the calling thread.
+        /// </summary>
+        /// <param name="item">The item to enqueue.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used to abort the enqueue operation.</param>
         void Enqueue(T item, CancellationToken cancellationToken);
 
+        /// <summary>
+        /// Enqueues an item to the producer/consumer queue. Throws <see cref="InvalidOperationException"/> if the producer/consumer queue has completed adding.
+        /// </summary>
+        /// <param name="item">The item to enqueue.</param>
         Task EnqueueAsync(T item);
+
+        /// <summary>
+        /// Enqueues an item to the producer/consumer queue. Throws <see cref="InvalidOperationException"/> if the producer/consumer queue has completed adding.
+        /// </summary>
+        /// <param name="item">The item to enqueue.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used to abort the enqueue operation.</param>
         Task EnqueueAsync(T item, CancellationToken cancellationToken);
 
+        /// <summary>
+        /// Attempts to enqueue an item to the producer/consumer queue. Returns <c>false</c> if the producer/consumer queue has completed adding. This method may block the calling thread.
+        /// </summary>
+        /// <param name="item">The item to enqueue.</param>
         bool TryEnqueue(T item);
+
+        /// <summary>
+        /// Attempts to enqueue an item to the producer/consumer queue. Returns <c>false</c> if the producer/consumer queue has completed adding. This method may block the calling thread.
+        /// </summary>
+        /// <param name="item">The item to enqueue.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used to abort the enqueue operation.</param>
         bool TryEnqueue(T item, CancellationToken cancellationToken);
 
+        /// <summary>
+        /// Attempts to enqueue an item to the producer/consumer queue. Returns <c>false</c> if the producer/consumer queue has completed adding.
+        /// </summary>
+        /// <param name="item">The item to enqueue.</param>
         Task<bool> TryEnqueueAsync(T item);
+
+        /// <summary>
+        /// Attempts to enqueue an item to the producer/consumer queue. Returns <c>false</c> if the producer/consumer queue has completed adding.
+        /// </summary>
+        /// <param name="item">The item to enqueue.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used to abort the enqueue operation.</param>
         Task<bool> TryEnqueueAsync(T item, CancellationToken cancellationToken);
         #endregion Enqueue
 
         #region Dequeue
+        /// <summary>
+        /// Dequeues an item from the producer/consumer queue. Returns the dequeued item. This method may block the calling thread. Throws <see cref="InvalidOperationException"/> if the producer/consumer queue has completed adding and is empty.
+        /// </summary>
+        /// <returns>The dequeued item.</returns>
         T Dequeue();
+
+        /// <summary>
+        /// Dequeues an item from the producer/consumer queue. Returns the dequeued item. This method may block the calling thread. Throws <see cref="InvalidOperationException"/> if the producer/consumer queue has completed adding and is empty.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token that can be used to abort the dequeue operation.</param>
         T Dequeue(CancellationToken cancellationToken);
 
+        /// <summary>
+        /// Dequeues an item from the producer/consumer queue. Returns the dequeued item. Throws <see cref="InvalidOperationException"/> if the producer/consumer queue has completed adding and is empty.
+        /// </summary>
+        /// <returns>The dequeued item.</returns>
         Task<T> DequeueAsync();
+
+        /// <summary>
+        /// Dequeues an item from the producer/consumer queue. Returns the dequeued item. Throws <see cref="InvalidOperationException"/> if the producer/consumer queue has completed adding and is empty.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token that can be used to abort the dequeue operation.</param>
+        /// <returns>The dequeued item.</returns>
         Task<T> DequeueAsync(CancellationToken cancellationToken);
 
+        /// <summary>
+        /// Attempts to dequeue an item from the producer/consumer queue. This method may block the calling thread.
+        /// </summary>
         AsyncProducerConsumerQueue<T>.DequeueResult TryDequeue();
+
+        /// <summary>
+        /// Attempts to dequeue an item from the producer/consumer queue. This method may block the calling thread.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token that can be used to abort the dequeue operation.</param>
         AsyncProducerConsumerQueue<T>.DequeueResult TryDequeue(CancellationToken cancellationToken);
 
+        /// <summary>
+        /// Attempts to dequeue an item from the producer/consumer queue.
+        /// </summary>
         Task<AsyncProducerConsumerQueue<T>.DequeueResult> TryDequeueAsync();
+
+        /// <summary>
+        /// Attempts to dequeue an item from the producer/consumer queue.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token that can be used to abort the dequeue operation.</param>
         Task<AsyncProducerConsumerQueue<T>.DequeueResult> TryDequeueAsync(CancellationToken cancellationToken);
         #endregion Dequeue
 
         #region CompleteAdding
+        /// <summary>
+        /// Synchronously marks the producer/consumer queue as complete for adding.
+        /// </summary>
         void CompleteAdding();
+
+        /// <summary>
+        /// Asynchronously marks the producer/consumer queue as complete for adding.
+        /// </summary>
+        [Obsolete("Use CompleteAdding() instead.")]
         Task CompleteAddingAsync();
+
+        /// <summary>
+        /// Gets whether this <see cref="AsyncProducerConsumerQueue{T}"/> has been marked as
+        /// complete for adding.
+        /// </summary>
         bool IsAddingCompleted { get; }
+
+        /// <summary>
+        /// Gets whether this <see cref="AsyncProducerConsumerQueue{T}"/> has been marked as
+        /// complete for adding and is empty.
+        /// </summary>
         bool IsCompleted { get; }
         #endregion CompleteAdding
 
         #region GetConsumingEnumerable
+        /// <summary>
+        /// Provides a (synchronous) consuming enumerable for items in the producer/consumer queue.
+        /// </summary>
         IEnumerable<T> GetConsumingEnumerable();
+
+        /// <summary>
+        /// Provides a (synchronous) consuming enumerable for items in the producer/consumer queue.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token that can be used to abort the synchronous enumeration.</param>
         IEnumerable<T> GetConsumingEnumerable(CancellationToken cancellationToken);
         #endregion GetConsumingEnumerable
 
         #region OutputAvailable
+        /// <summary>
+        /// Asynchronously waits until an item is available to dequeue. Returns <c>false</c> if the producer/consumer queue has completed adding and there are no more items.
+        /// </summary>
         Task<bool> OutputAvailableAsync();
+
+        /// <summary>
+        /// Asynchronously waits until an item is available to dequeue. Returns <c>false</c> if the producer/consumer queue has completed adding and there are no more items.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token that can be used to abort the asynchronous wait.</param>
         Task<bool> OutputAvailableAsync(CancellationToken cancellationToken);
         #endregion OutputAvailable
     }

--- a/Source/Nito.AsyncEx (NET45, Win8, WP8, WPA81)/IAsyncProducerConsumerQueue.cs
+++ b/Source/Nito.AsyncEx (NET45, Win8, WP8, WPA81)/IAsyncProducerConsumerQueue.cs
@@ -1,0 +1,58 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nito.AsyncEx
+{
+    /// <summary>
+    /// An async-compatible producer/consumer queue.
+    /// </summary>
+    /// <typeparam name="T">The type of elements contained in the queue.</typeparam>
+    public interface IAsyncProducerConsumerQueue<T>
+    {
+        #region Enqueue
+        void Enqueue(T item);
+        void Enqueue(T item, CancellationToken cancellationToken);
+
+        Task EnqueueAsync(T item);
+        Task EnqueueAsync(T item, CancellationToken cancellationToken);
+
+        bool TryEnqueue(T item);
+        bool TryEnqueue(T item, CancellationToken cancellationToken);
+
+        Task<bool> TryEnqueueAsync(T item);
+        Task<bool> TryEnqueueAsync(T item, CancellationToken cancellationToken);
+        #endregion Enqueue
+
+        #region Dequeue
+        T Dequeue();
+        T Dequeue(CancellationToken cancellationToken);
+
+        Task<T> DequeueAsync();
+        Task<T> DequeueAsync(CancellationToken cancellationToken);
+
+        AsyncProducerConsumerQueue<T>.DequeueResult TryDequeue();
+        AsyncProducerConsumerQueue<T>.DequeueResult TryDequeue(CancellationToken cancellationToken);
+
+        Task<AsyncProducerConsumerQueue<T>.DequeueResult> TryDequeueAsync();
+        Task<AsyncProducerConsumerQueue<T>.DequeueResult> TryDequeueAsync(CancellationToken cancellationToken);
+        #endregion Dequeue
+
+        #region CompleteAdding
+        void CompleteAdding();
+        Task CompleteAddingAsync();
+        bool IsAddingCompleted { get; }
+        bool IsCompleted { get; }
+        #endregion CompleteAdding
+
+        #region GetConsumingEnumerable
+        IEnumerable<T> GetConsumingEnumerable();
+        IEnumerable<T> GetConsumingEnumerable(CancellationToken cancellationToken);
+        #endregion GetConsumingEnumerable
+
+        #region OutputAvailable
+        Task<bool> OutputAvailableAsync();
+        Task<bool> OutputAvailableAsync(CancellationToken cancellationToken);
+        #endregion OutputAvailable
+    }
+}

--- a/Source/Nito.AsyncEx (NET45, Win8, WP8, WPA81)/Nito.AsyncEx (NET45, Win8, WP8, WPA81).csproj
+++ b/Source/Nito.AsyncEx (NET45, Win8, WP8, WPA81)/Nito.AsyncEx (NET45, Win8, WP8, WPA81).csproj
@@ -90,6 +90,7 @@
     <Compile Include="DeferralManager.cs" />
     <Compile Include="Deque.cs" />
     <Compile Include="ExceptionHelpers.cs" />
+    <Compile Include="IAsyncProducerConsumerQueue.cs" />
     <Compile Include="Internal\IdManager.cs" />
     <Compile Include="Internal\ReflectionShim.cs" />
     <Compile Include="Internal\TaskShim.cs" />

--- a/Source/Nito.AsyncEx.Dataflow.nuspec
+++ b/Source/Nito.AsyncEx.Dataflow.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>Nito.AsyncEx.Dataflow</id>
-    <version>$version$</version>
+    <version>3.0.1-zhivepeople2</version> <!-- Also change [AssemblyVersion] and Nito.AsyncEx.nuspec -->
     <title>Dataflow Helpers</title>
     <authors>Stephen Cleary</authors>
     <owners>Stephen Cleary</owners>

--- a/Source/Nito.AsyncEx.Dataflow.nuspec
+++ b/Source/Nito.AsyncEx.Dataflow.nuspec
@@ -2,7 +2,6 @@
 <package>
   <metadata>
     <id>Nito.AsyncEx.Dataflow</id>
-    <version>3.0.1-zhivepeople1</version> <!-- Also change [AssemblyVersion] and Nito.AsyncEx.nuspec -->
     <title>Dataflow Helpers</title>
     <authors>Stephen Cleary</authors>
     <owners>Stephen Cleary</owners>

--- a/Source/Nito.AsyncEx.Dataflow.nuspec
+++ b/Source/Nito.AsyncEx.Dataflow.nuspec
@@ -2,6 +2,7 @@
 <package>
   <metadata>
     <id>Nito.AsyncEx.Dataflow</id>
+    <version>$version$</version>
     <title>Dataflow Helpers</title>
     <authors>Stephen Cleary</authors>
     <owners>Stephen Cleary</owners>

--- a/Source/Nito.AsyncEx.nuspec
+++ b/Source/Nito.AsyncEx.nuspec
@@ -2,7 +2,6 @@
 <package>
   <metadata>
     <id>Nito.AsyncEx</id>
-    <version>3.0.1-zhivepeople1</version> <!-- Also change [AssemblyVersion] and Nito.AsyncEx.Dataflow.nuspec -->
     <title>Async and Task Helpers</title>
     <authors>Stephen Cleary</authors>
     <owners>Stephen Cleary</owners>

--- a/Source/Nito.AsyncEx.nuspec
+++ b/Source/Nito.AsyncEx.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>Nito.AsyncEx</id>
-    <version>$version$</version>
+    <version>3.0.1-zhivepeople2</version> <!-- Also change [AssemblyVersion] and Nito.AsyncEx.Dataflow.nuspec -->
     <title>Async and Task Helpers</title>
     <authors>Stephen Cleary</authors>
     <owners>Stephen Cleary</owners>

--- a/Source/Nito.AsyncEx.nuspec
+++ b/Source/Nito.AsyncEx.nuspec
@@ -2,6 +2,7 @@
 <package>
   <metadata>
     <id>Nito.AsyncEx</id>
+    <version>$version$</version>
     <title>Async and Task Helpers</title>
     <authors>Stephen Cleary</authors>
     <owners>Stephen Cleary</owners>

--- a/Source/SharedAssemblyInfo.cs
+++ b/Source/SharedAssemblyInfo.cs
@@ -9,4 +9,4 @@ using System.Runtime.InteropServices;
 [assembly: CLSCompliant(false)]
 
 [assembly: AssemblyVersion("3.0.1.2")]
-[assembly: AssemblyInformationalVersion("3.0.1-zhivepeople2")]
+[assembly: AssemblyInformationalVersion("3.0.1-zhivepeople2")]  // Also change Nito.AsyncEx.nuspec and Nito.AsyncEx.Dataflow.nuspec -->

--- a/Source/SharedAssemblyInfo.cs
+++ b/Source/SharedAssemblyInfo.cs
@@ -8,5 +8,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("Copyright © 2011-2014 Stephen Cleary")]
 [assembly: CLSCompliant(false)]
 
-[assembly: AssemblyVersion("3.0.1")]
-[assembly: AssemblyInformationalVersion("3.0.1-zhivepeople1")]
+[assembly: AssemblyVersion("3.0.1.2")]
+[assembly: AssemblyInformationalVersion("3.0.1-zhivepeople2")]


### PR DESCRIPTION
- fix: AsyncProducerConsumerQueue.IsCompleted would hang in some unit
  tests due to attempt to lock same AsyncLock twice, which won't work
  since AsyncLock is not reentrant/recursive; fixed by accessing the
  underlying queue directly instead of enumerating the async queue; this
  also changes the operation to O(1) from O(N)
- add: extract interface for AsyncProducerConsumerQueue so we can mock it
  in unit tests
- version: bump hivepeople version number
