### PR TITLE
Interface for async queue must be enumerable

### DIFF
--- a/Source/Nito.AsyncEx (NET45, Win8, WP8, WPA81)/AsyncProducerConsumerQueue.cs
+++ b/Source/Nito.AsyncEx (NET45, Win8, WP8, WPA81)/AsyncProducerConsumerQueue.cs
@@ -16,7 +16,7 @@ namespace Nito.AsyncEx
     /// <typeparam name="T">The type of elements contained in the queue.</typeparam>
     [DebuggerDisplay("Count = {_queue.Count}, MaxCount = {_maxCount}")]
     [DebuggerTypeProxy(typeof(AsyncProducerConsumerQueue<>.DebugView))]
-    public sealed class AsyncProducerConsumerQueue<T> : IEnumerable<T>, IDisposable, IAsyncProducerConsumerQueue<T>
+    public sealed class AsyncProducerConsumerQueue<T> : IAsyncProducerConsumerQueue<T>, IDisposable
     {
         /// <summary>
         /// The underlying queue.

--- a/Source/Nito.AsyncEx (NET45, Win8, WP8, WPA81)/IAsyncProducerConsumerQueue.cs
+++ b/Source/Nito.AsyncEx (NET45, Win8, WP8, WPA81)/IAsyncProducerConsumerQueue.cs
@@ -9,7 +9,7 @@ namespace Nito.AsyncEx
     /// An async-compatible producer/consumer queue.
     /// </summary>
     /// <typeparam name="T">The type of elements contained in the queue.</typeparam>
-    public interface IAsyncProducerConsumerQueue<T>
+    public interface IAsyncProducerConsumerQueue<T> : IEnumerable<T>
     {
         #region Enqueue
         /// <summary>

--- a/Source/Nito.AsyncEx.Dataflow.nuspec
+++ b/Source/Nito.AsyncEx.Dataflow.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>Nito.AsyncEx.Dataflow</id>
-    <version>3.0.1-zhivepeople2</version> <!-- Also change [AssemblyVersion] and Nito.AsyncEx.nuspec -->
+    <version>3.0.1-zhivepeople3</version> <!-- Also change [AssemblyVersion] and Nito.AsyncEx.nuspec -->
     <title>Dataflow Helpers</title>
     <authors>Stephen Cleary</authors>
     <owners>Stephen Cleary</owners>

--- a/Source/Nito.AsyncEx.nuspec
+++ b/Source/Nito.AsyncEx.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>Nito.AsyncEx</id>
-    <version>3.0.1-zhivepeople2</version> <!-- Also change [AssemblyVersion] and Nito.AsyncEx.Dataflow.nuspec -->
+    <version>3.0.1-zhivepeople3</version> <!-- Also change [AssemblyVersion] and Nito.AsyncEx.Dataflow.nuspec -->
     <title>Async and Task Helpers</title>
     <authors>Stephen Cleary</authors>
     <owners>Stephen Cleary</owners>

--- a/Source/SharedAssemblyInfo.cs
+++ b/Source/SharedAssemblyInfo.cs
@@ -9,4 +9,4 @@ using System.Runtime.InteropServices;
 [assembly: CLSCompliant(false)]
 
 [assembly: AssemblyVersion("3.0.1.2")]
-[assembly: AssemblyInformationalVersion("3.0.1-zhivepeople2")]  // Also change Nito.AsyncEx.nuspec and Nito.AsyncEx.Dataflow.nuspec -->
+[assembly: AssemblyInformationalVersion("3.0.1-zhivepeople3")]  // Also change Nito.AsyncEx.nuspec and Nito.AsyncEx.Dataflow.nuspec -->


### PR DESCRIPTION
- fix: IAsyncProducerConsumerQueue<T> must implement IEnumerable<T>, so
  we don't have to do crazy casts when working with the interface
